### PR TITLE
Prevent generated method signatures from sometimes having extra whitespace at the end

### DIFF
--- a/src/mddoc.nim
+++ b/src/mddoc.nim
@@ -42,6 +42,7 @@ for entry in doc["entries"]:
       .replace("{.raises: [], tags: [].}", "")
       .replace(", raises: []", "")
       .replace(", tags: []", "")
+      .strip()
     md.add "\n```\n"
   md.add "\n"
 


### PR DESCRIPTION
See https://github.com/guzba/chroma/commit/dad475fb11cc8a045e818207f83d4b16ec0c1ef3