### PR TITLE
process &lt; and &gt; in entry name

### DIFF
--- a/src/mddoc.nim
+++ b/src/mddoc.nim
@@ -25,8 +25,11 @@ for entry in doc["entries"]:
   echo "* ", entry["name"].getStr()
   md.add "## **" &
       entry["type"].getStr()[2..^1].toLowerAscii() &
-      "** " & entry["name"].getStr() & "\n"
-  md.add "\n"
+      "** "
+  md.add entry["name"].getStr()
+    .replace("&lt;", "<")
+    .replace("&gt;", ">")
+  md.add "\n\n"
   if "description" in entry:
     md.add entry["description"].getStr()
       .replace("<ul class=\"simple\">", "\n")


### PR DESCRIPTION
Hi, while building api docs for bigints (see https://github.com/pietroppeter/nim-bigints/tree/add-api-docs-in-readme) I ran into this minor issue that entries which have `<` or `>` in the name do not render correctly. This fix address this issue. I cannot at the moment think of other problematic symbols, but if you come up with others I can add them to this PR.